### PR TITLE
Add .readthedocs.yaml since it's required soon

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+# Read the Docs configuration file for MkDocs projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Using mkdocs
+mkdocs:
+  configuration: mkdocs.yml


### PR DESCRIPTION
Bumps used Python version from 2 to 3 but otherwise nothing should change.